### PR TITLE
signing key rotation

### DIFF
--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -7,9 +7,9 @@
 
 - name: Import InfluxData GPG signing key
   apt_key:
-    url: https://repos.influxdata.com/influxdb.key
+    url: https://repos.influxdata.com/influxdata-archive_compat.key
     state: present
-    id: "0x2582E0C5"
+    id: "0x7DF8B07E"
 
 - name: Add InfluxData repository
   apt_repository:


### PR DESCRIPTION
## Changes

https://www.influxdata.com/blog/linux-package-signing-key-rotation/

Influxdb revoked 2582E0C5 on 2023-04-27.

The playbook fails at the install step on a fresh instance as a result.

## Verify

The new key fixes the problem for us at usegalaxy.ca
