### PR TITLE
Replaced include module with import_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,20 +23,20 @@
   when: ssl_cert_group_available is defined and ssl_cert_group_available
 
 - name: Configure collectd
-  include: collectd.yml
+  import_tasks: collectd.yml
   when: influxdb_collectd_enabled == "true"
 
-- include: install-download.yml
+- import_tasks: install-download.yml
   when: influxdb_install_method == "download"
   tags:
     - influxdb
 
-- include: install-debian.yml
+- import_tasks: install-debian.yml
   when: influxdb_install_method == "repository" and ansible_distribution in ["Debian", "Ubuntu"]
   tags:
     - influxdb
 
-- include: install-rhel.yml
+- import_tasks: install-rhel.yml
   when: influxdb_install_method == "repository" and ansible_distribution in ["Enterprise Linux", "CentOS"]
   tags:
     - influxdb


### PR DESCRIPTION
include module is removed from the ansible-core in a release after 2023-05-16

## Changes
Replaced the `include` module with `import_tasks` , because `incude` module is removed from the latest version of ansible-core

## Verify

Update the ansible ansible versiont to core 2.16.2 and run the playbook, it will break with an error message "include" is deprecated, use include_tasks/import_tasks instead." in this PR replaced the `include` module with `import_tasks` which does not give any errors.


